### PR TITLE
Feature: No name attribute

### DIFF
--- a/app/js/meta.js
+++ b/app/js/meta.js
@@ -66,13 +66,33 @@ angular.module('sn.meta', ['ngRoute'])
       link: function ($scope, $element, $attrs) {
 
         /**
+         * Can be either 'name', 'itemprop' or 'property'
+         * @property keyAttr
+         * @type     {Object}
+         */
+        var keyAttr = 'name';
+
+        /**
+         * Determines whether the element using either 'name',
+         * 'itemprop' or 'property' attributes as it's key.
+         * @method findKeyValue
+         */
+        var findKeyValue = function findKeyValue() {
+          if ($attrs.property) {
+            keyAttr = 'property';
+          } else if ($attrs.itemprop) {
+            keyAttr = 'itemprop';
+          }
+        };
+
+        /**
          * @method setMeta
          * @param  {event}  $event - '$routeChangeSuccess' event from ngRoute service
          * @param  {Object} meta   - The requested route object
          */
         var setMeta = function setMeta(event, meta){
-          if ( meta[$attrs.name] ) {
-            $element.attr('content', meta[$attrs.name]);
+          if ( meta[ $attrs[keyAttr] ] ) {
+            $element.attr('content', meta[ $attrs[keyAttr] ]);
           }
         };
 
@@ -89,9 +109,9 @@ angular.module('sn.meta', ['ngRoute'])
           if (current &&
               current.$$route &&
               current.$$route.meta &&
-              current.$$route.meta[$attrs.name]
+              current.$$route.meta[ $attrs[keyAttr] ]
           ) {
-            content = current.$$route.meta[$attrs.name];
+            content = current.$$route.meta[ $attrs[keyAttr] ];
           }
 
           $element.attr('content', content);
@@ -110,6 +130,8 @@ angular.module('sn.meta', ['ngRoute'])
         $rootScope.$on(snMetaEvents.SET_META, setMeta);
         $rootScope.$on(snMetaEvents.ROUTE_CHANGE_SUCCESS, onRouteChangeSuccess);
         $rootScope.$on(snMetaEvents.ROUTE_CHANGE_ERROR, onRouteChangeError);
+
+        findKeyValue();
 
       }
     };

--- a/tests/unit/meta.js
+++ b/tests/unit/meta.js
@@ -47,6 +47,56 @@ describe('sn.meta:meta directive', function() {
       expect(element.attr('content')).not.toEqual('some content');
     });
   });
+
+  describe('property as key', function() {
+
+    beforeEach(inject(function (_$rootScope_, $compile, $injector) {
+
+      element = '<meta property="description" content="Page description. No longer than 155 characters." />';
+
+      element = $compile(element)($scope);
+      $scope.$digest();
+
+    }));
+
+    it('should render directive with correct meta data', function(){
+      $rootScope.$broadcast("$routeChangeSuccess", {
+        $$route: {
+          meta: {
+            description: 'pageone description'
+          }
+        }
+      })
+      expect(element.attr('content')).toEqual('pageone description');
+
+    });
+
+  });
+
+  describe('itemprop as key', function() {
+
+    beforeEach(inject(function (_$rootScope_, $compile, $injector) {
+
+      element = '<meta itemprop="description" content="Page description. No longer than 155 characters." />';
+
+      element = $compile(element)($scope);
+      $scope.$digest();
+
+    }));
+
+    it('should render directive with correct meta data', function(){
+      $rootScope.$broadcast("$routeChangeSuccess", {
+        $$route: {
+          meta: {
+            description: 'pageone description'
+          }
+        }
+      })
+      expect(element.attr('content')).toEqual('pageone description');
+
+    });
+
+  });
 });
 
 describe('sn.meta:snMeta service', function() {


### PR DESCRIPTION
Some meta tags use `itemprop` or `property` attributes instead of name. This PR will add support for this.